### PR TITLE
Can now get coverage across multiple test sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ typings/
 
 
 # End of https://www.gitignore.io/api/node
+
+.coverage_tmp

--- a/guefile.js
+++ b/guefile.js
@@ -21,7 +21,7 @@ fileSet.add(
 fileSet.add('packageJson', 'package.json', 'rebuild');
 
 // Cleaners
-fileSet.add('clean', ['coverage', '.nyc_output']);
+fileSet.add('clean', ['coverage', '.nyc_output', '.coverage_tmp']);
 fileSet.add('distclean', ['node_modules']);
 
 // Documentation
@@ -49,17 +49,30 @@ gue.task('lint', () => {
   return gue.shell('eslint {{globs "allSrc"}}');
 });
 
-gue.task('test', ['clean'], () => {
+gue.task('test', () => {
   return gue.shell(
-    'nyc --reporter lcov --reporter text ' + 'mocha {{files "unitTests"}}'
+    'nyc --reporter lcov --no-clean --silent --temp-directory=./.coverage_tmp ' +
+      'mocha {{files "unitTests"}}'
   );
 });
 
 gue.task('integration', () => {
-  let command = 'mocha {{globs "integrationTests"}}';
-  return gue.shell(command);
+  return gue.shell(
+    'nyc --reporter lcov --no-clean --silent --temp-directory=./.coverage_tmp ' +
+      'mocha {{globs "integrationTests"}}'
+  );
 });
 
+// Run all the tests and print the coverage report
+gue.task('coverage', ['clean', 'test', 'integration', 'cov_report']);
+
+// Print coverage information
+// It's up to the tests to record their coverage data in .coverage_tmp
+gue.task('cov_report', () => {
+  return gue.shell(
+    'nyc  --temp-directory=./.coverage_tmp --reporter text --reporter lcov report'
+  );
+});
 //
 // Cleaners
 //
@@ -79,14 +92,7 @@ gue.task('docClean', () => {
 //
 // Build
 //
-gue.task('rebuild', [
-  'distclean',
-  'yarn',
-  'lint',
-  'test',
-  'integration',
-  'buildDocs'
-]);
+gue.task('rebuild', ['distclean', 'yarn', 'lint', 'coverage', 'buildDocs']);
 
 gue.task('yarn', () => {
   return gue.shell('yarn');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A task runner with shell powers",
   "main": "index.js",
   "scripts": {
-    "test": "node ./bin/gue.js test integration",
+    "test": "node ./bin/gue.js lint spell coverage",
     "clean": "node ./bin/gue.js clean",
     "docs": "node ./bin/gue.js docs"
   },


### PR DESCRIPTION
added the --no-clean option to the nyc test runs
Added cov_report to report on the accumulated coverage data
added coverage task that runs all tests and prints coverage report
updated npm test to run lint/spell/coverage
update rebuild to use the coverage task

fixes #52